### PR TITLE
Add configurable battle music distance

### DIFF
--- a/src/main/java/com/nekotune/battlemusic/BattleMusic.java
+++ b/src/main/java/com/nekotune/battlemusic/BattleMusic.java
@@ -41,7 +41,6 @@ public class BattleMusic
     public static final String MOD_ID = "battlemusic";
     public static final Logger LOGGER = LogUtils.getLogger();
     public static final float VOLUME_REDUCTION = 2f;
-    public static final double MAX_SONG_RANGE = 256D;
     public static BattleMusicInstance playing = null;
     private static float volume = 1f;
     public static ArrayList<Mob> validEntities = new ArrayList<>();
@@ -177,13 +176,18 @@ public class BattleMusic
                 && !mob.isSleeping() && !mob.isNoAi()
                 && !mob.isAlliedTo(player.self())
                 && !(mob instanceof NeutralMob && !mob.isAggressive())) {
+            double maxMusicDistance = ModConfigs.MAX_MUSIC_DISTANCE.get();
             AttributeInstance frAttribute = mob.getAttribute(Attributes.FOLLOW_RANGE);
-            double followRange = (frAttribute != null) ? frAttribute.getValue() : MAX_SONG_RANGE;
+            double followRange = (frAttribute != null) ? frAttribute.getValue() : maxMusicDistance;
+            double attackRange = Math.max(followRange, maxMusicDistance);
             if (mob instanceof EnderDragon) {
-                followRange = 300; // Because the ender dragon is special
+                attackRange = Math.max(attackRange, 300D); // Because the ender dragon is special
+            }
+            if (player.distanceToSqr(mob) > maxMusicDistance * maxMusicDistance) {
+                return false;
             }
             if (toStart && (!player.hasLineOfSight(mob) || !mob.hasLineOfSight(player))) return false;
-            return mob.canAttack(player, TargetingConditions.forCombat().range(followRange).ignoreLineOfSight().ignoreInvisibilityTesting());
+            return mob.canAttack(player, TargetingConditions.forCombat().range(attackRange).ignoreLineOfSight().ignoreInvisibilityTesting());
         }
         return false;
     }

--- a/src/main/java/com/nekotune/battlemusic/ModConfigs.java
+++ b/src/main/java/com/nekotune/battlemusic/ModConfigs.java
@@ -16,6 +16,7 @@ public abstract class ModConfigs
     public static final ForgeConfigSpec.ConfigValue<Integer> HEALTH_PITCH_THRESH;
     public static final ForgeConfigSpec.ConfigValue<Boolean> HEALTH_PITCH_PERCENT;
     public static final ForgeConfigSpec.ConfigValue<Double> FADE_TIME;
+    public static final ForgeConfigSpec.ConfigValue<Double> MAX_MUSIC_DISTANCE;
     public static final ForgeConfigSpec.ConfigValue<List<? extends String>> ENTITIES_SONGS;
     public static final ForgeConfigSpec.ConfigValue<String> DEFAULT_SONG;
 
@@ -47,6 +48,11 @@ public abstract class ModConfigs
                 .define("health_pitch_percent", false);
         FADE_TIME = BUILDER.comment("\nHow many seconds songs take to fade in and out")
                         .defineInRange("fade_time", 1D, 0D, 10D);
+        MAX_MUSIC_DISTANCE = BUILDER.comment("""
+                        Maximum distance (in blocks) from an engaged entity before battle music fades out   \s
+                            > Increase this value to hear battle music from farther away   \s
+                            > Decrease this value to make battle music stop sooner   \s""")
+                        .defineInRange("max_music_distance", 256D, 32D, 1024D);
         ENTITIES_SONGS = BUILDER.comment("""
 
                         Entites and their respective songs, write in entity;song;priority format      \s


### PR DESCRIPTION
## Summary
- add a client config entry that controls how far battle music can be heard before it fades out
- use the configured distance when validating battle music entities so it adjusts the fade-out range

## Testing
- ./gradlew build *(fails: missing com.aetherteam dependencies in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67e6eba288321885a7e2ee8a0f352