### PR TITLE
Remove direct Aether dependency for build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,33 +63,12 @@ repositories {
 }
 
 
-configurations.configureEach {
-    // Force any accidental NeoForge-mapped requests back to the correct Forge artifacts
-    resolutionStrategy.eachDependency { details ->
-        def r = details.requested
-        if (r.group == 'com.aetherteam.aether' && r.name == 'aether') {
-            details.useTarget "com.aetherteam.aether:aether:1.20.1-1.4.2-forge"
-        }
-        if (r.group == 'com.aetherteam.nitrogen' && r.name == 'nitrogen_internals') {
-            details.useTarget "com.aetherteam.nitrogen:nitrogen_internals:1.20.1-1.0.9-forge"
-        }
-    }
-}
-
 dependencies {
     // Forge
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
     // jopt-simple pin
     implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
-
-    // Aether/Nitrogen — Forge variants (dev-time deobf)
-    compileOnly fg.deobf("com.aetherteam.aether:aether:1.20.1-1.4.2-forge")
-    compileOnly fg.deobf("com.aetherteam.nitrogen:nitrogen_internals:1.20.1-1.0.9-forge")
-
-    // If you want them present in your dev runs, also add:
-    // runtimeOnly fg.deobf("com.aetherteam.aether:aether:1.20.1-1.4.2-forge")
-    // runtimeOnly fg.deobf("com.aetherteam.nitrogen:nitrogen_internals:1.20.1-1.0.9-forge")
 }
 
 tasks.named('processResources', ProcessResources).configure {

--- a/src/main/java/com/nekotune/battlemusic/compat/AetherCompat.java
+++ b/src/main/java/com/nekotune/battlemusic/compat/AetherCompat.java
@@ -1,22 +1,48 @@
 package com.nekotune.battlemusic.compat;
 
-import com.aetherteam.nitrogen.entity.BossMob;
 import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @OnlyIn(Dist.CLIENT)
 public abstract class AetherCompat {
-    public final static String ACTIVE_BOSS_TAG = "active_boss_aether";
+    public static final String ACTIVE_BOSS_TAG = "active_boss_aether";
+
+    private static final String BOSS_MOB_CLASS = "com.aetherteam.nitrogen.entity.BossMob";
+    private static final Class<?> bossMobClass;
+    private static final Method isBossFightMethod;
+
+    static {
+        Class<?> clazz = null;
+        Method method = null;
+
+        try {
+            clazz = Class.forName(BOSS_MOB_CLASS);
+            method = clazz.getMethod("isBossFight");
+        } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+            // The Aether isn't present; compatibility hooks remain inactive.
+        }
+
+        bossMobClass = clazz;
+        isBossFightMethod = method;
+    }
 
     public static boolean isBoss(Mob mob) {
-        return mob instanceof BossMob;
+        return bossMobClass != null && bossMobClass.isInstance(mob);
     }
 
     public static boolean isActiveBoss(Mob mob) {
-        if (mob instanceof BossMob) {
-            return ((BossMob<?>)mob).isBossFight();
+        if (!isBoss(mob) || isBossFightMethod == null) {
+            return false;
         }
-        return false;
+
+        try {
+            return Boolean.TRUE.equals(isBossFightMethod.invoke(mob));
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- remove the compile-time Aether/Nitrogen dependencies that could not be resolved
- rework the Aether compatibility helper to detect Boss mobs via reflection so the feature still works without the jars on the classpath

## Testing
- ./gradlew compileJava *(fails: 403 Forbidden while downloading net.minecraftforge:mergetool)*

------
https://chatgpt.com/codex/tasks/task_e_68e688fa7b7483218adcbf9a66490b32